### PR TITLE
feat(costco): add Costco brand with auth flow

### DIFF
--- a/getgather/mcp/costco.py
+++ b/getgather/mcp/costco.py
@@ -1,0 +1,21 @@
+from typing import Any
+
+import zendriver as zd
+
+from getgather.mcp.dpage import remote_zen_dpage_with_action
+from getgather.mcp.registry import MCPTool
+
+costco_mcp = MCPTool.registry["costco"]
+
+
+@costco_mcp.tool
+async def get_orders() -> dict[str, Any]:
+    """Get order history from a user's Costco account."""
+
+    async def _action(_page: zd.Tab, _browser: zd.Browser) -> dict[str, Any]:
+        return {"costco_orders": []}
+
+    return await remote_zen_dpage_with_action(
+        "https://www.costco.com/my/AccountHomeView",
+        action=_action,
+    )

--- a/getgather/mcp/main.py
+++ b/getgather/mcp/main.py
@@ -111,7 +111,7 @@ class LocationProxyMiddleware(Middleware):
 MCP_BUNDLES: dict[str, list[str]] = {
     "media": ["bbc", "cnn", "espn", "groundnews", "npr", "nytimes"],
     "books": ["goodreads"],
-    "shopping": ["amazon", "amazonca", "shopee", "wayfair", "kroger"],
+    "shopping": ["amazon", "amazonca", "shopee", "wayfair", "kroger", "costco"],
     "sports": ["garmin"],
     "food": ["doordash"],
 }

--- a/getgather/mcp/mcp-tools.yaml
+++ b/getgather/mcp/mcp-tools.yaml
@@ -375,6 +375,14 @@
     - function_name: get_purchases_in_store
       description: Get purchases in store from a user Safeway account.
 
+- id: costco
+  name: Costco MCP
+  custom: true
+  module: costco
+  tools:
+    - function_name: get_orders
+      description: Get order history from a user's Costco account.
+
 - id: lazada
   name: Lazada MCP
   tools:

--- a/getgather/mcp/patterns/costco-home-loggedin.html
+++ b/getgather/mcp/patterns/costco-home-loggedin.html
@@ -1,0 +1,8 @@
+<html gg-domain="costco">
+  <head>
+    <title>Costco Home Logged In</title>
+  </head>
+  <body>
+    <div gg-stop gg-match="div[data-testid='icon-orderspurchasesID']"></div>
+  </body>
+</html>

--- a/getgather/mcp/patterns/costco-membership-expired.html
+++ b/getgather/mcp/patterns/costco-membership-expired.html
@@ -1,0 +1,9 @@
+<html gg-domain="costco">
+  <head>
+    <title>Costco Membership Expired</title>
+  </head>
+  <body>
+    <div gg-match="h1[automation-id='expiredMembershipOutputText']"></div>
+    <div gg-autoclick gg-match="a#header_order_and_returns"></div>
+  </body>
+</html>

--- a/getgather/mcp/patterns/costco-membership-new.html
+++ b/getgather/mcp/patterns/costco-membership-new.html
@@ -1,0 +1,9 @@
+<html gg-domain="costco">
+  <head>
+    <title>Costco Membership New</title>
+  </head>
+  <body>
+    <div gg-match="h1[automation-id='linkYourMembership']"></div>
+    <div gg-autoclick gg-match="a#header_order_and_returns"></div>
+  </body>
+</html>

--- a/getgather/mcp/patterns/costco-orders.html
+++ b/getgather/mcp/patterns/costco-orders.html
@@ -1,0 +1,8 @@
+<html gg-domain="costco">
+  <head>
+    <title>Costco Orders</title>
+  </head>
+  <body>
+    <div gg-stop gg-match="div[automation-id='noOrdersAvailableNotification']"></div>
+  </body>
+</html>

--- a/getgather/mcp/patterns/costco-passcode-code.html
+++ b/getgather/mcp/patterns/costco-passcode-code.html
@@ -1,0 +1,51 @@
+<html gg-domain="costco" gg-action-delay="200">
+  <head>
+    <title>Costco Sign In Passcode</title>
+  </head>
+  <body>
+    <p gg-optional gg-match="div#emailVerificationControl_error_message"></p>
+    <p gg-optional gg-match="div.itemLevel[role='alert']"></p>
+
+    <input
+      autofocus
+      name="code"
+      type="text"
+      placeholder="Verification Code"
+      gg-match="input#VerificationCode"
+    />
+
+    <button
+      type="submit"
+      gg-match="button#emailVerificationControl_but_verify_code:not([disabled])"
+    >
+      Sign In
+    </button>
+
+    <div style="display: flex; flex-direction: column">
+      <div
+        style="
+          display: flex;
+          align-items: center;
+          text-align: center;
+          width: 100%;
+          margin-bottom: 12px;
+        "
+      >
+        <div style="position: relative; text-align: center; width: 100%">
+          <hr />
+        </div>
+      </div>
+      <div style="display: flex; flex-direction: row; gap: 12px">
+        <button
+          name="button"
+          value="send_new_code"
+          gg-optional
+          gg-match="button#emailVerificationControl_but_send_new_code"
+        >
+          Send New Code
+        </button>
+        <button name="button" value="cancel" gg-optional gg-match="button#cancel">Cancel</button>
+      </div>
+    </div>
+  </body>
+</html>

--- a/getgather/mcp/patterns/costco-passcode-email.html
+++ b/getgather/mcp/patterns/costco-passcode-email.html
@@ -1,0 +1,31 @@
+<html gg-domain="costco" gg-action-delay="200">
+  <head>
+    <title>Sign In with a One Time Password</title>
+  </head>
+  <body>
+    <p gg-optional gg-match="div#emailVerificationControl_error_message"></p>
+
+    <input autofocus name="email" type="email" placeholder="Email" gg-match="input#email" />
+
+    <button type="submit" gg-match="button#emailVerificationControl_but_send_code:not([disabled])">
+      Sign In
+    </button>
+
+    <div style="display: flex; flex-direction: column">
+      <div
+        style="
+          display: flex;
+          align-items: center;
+          text-align: center;
+          width: 100%;
+          margin-bottom: 12px;
+        "
+      >
+        <div style="position: relative; text-align: center; width: 100%">
+          <hr />
+        </div>
+      </div>
+      <button name="button" value="cancel" gg-optional gg-match="button#cancel">Cancel</button>
+    </div>
+  </body>
+</html>

--- a/getgather/mcp/patterns/costco-pre-signin.html
+++ b/getgather/mcp/patterns/costco-pre-signin.html
@@ -1,0 +1,8 @@
+<html gg-domain="costco">
+  <head>
+    <title>Costco Pre Sign In</title>
+  </head>
+  <body>
+    <div gg-autoclick gg-match="button[data-testid='Button_search-strip-member-links-desktop-signin-desktop']"></div>
+  </body>
+</html>

--- a/getgather/mcp/patterns/costco-pre-signin.html
+++ b/getgather/mcp/patterns/costco-pre-signin.html
@@ -3,6 +3,9 @@
     <title>Costco Pre Sign In</title>
   </head>
   <body>
-    <div gg-autoclick gg-match="button[data-testid='Button_search-strip-member-links-desktop-signin-desktop']"></div>
+    <div
+      gg-autoclick
+      gg-match="button[data-testid='Button_search-strip-member-links-desktop-signin-desktop']"
+    ></div>
   </body>
 </html>

--- a/getgather/mcp/patterns/costco-signin.html
+++ b/getgather/mcp/patterns/costco-signin.html
@@ -1,0 +1,23 @@
+<html gg-domain="costco">
+  <head>
+    <title>Costco Sign In</title>
+  </head>
+  <body>
+    <input
+      autofocus
+      name="email"
+      type="email"
+      placeholder="Email"
+      gg-match="form#localAccountForm input#signInName"
+    />
+    <input
+      name="password"
+      type="password"
+      placeholder="Password"
+      gg-match="form#localAccountForm input#password"
+    />
+    <button type="submit" gg-match="form#localAccountForm button#next:not([disabled])">
+      Sign In
+    </button>
+  </body>
+</html>

--- a/getgather/mcp/patterns/costco-signin.html
+++ b/getgather/mcp/patterns/costco-signin.html
@@ -1,8 +1,10 @@
-<html gg-domain="costco">
+<html gg-domain="costco" gg-action-delay="200">
   <head>
     <title>Costco Sign In</title>
   </head>
   <body>
+    <p gg-optional gg-match="div.pageLevel"></p>
+
     <input
       autofocus
       name="email"
@@ -19,5 +21,42 @@
     <button type="submit" gg-match="form#localAccountForm button#next:not([disabled])">
       Sign In
     </button>
+
+    <div style="display: flex; flex-direction: column">
+      <div
+        style="
+          display: flex;
+          align-items: center;
+          text-align: center;
+          width: 100%;
+          margin-top: 12px;
+          margin-bottom: 24px;
+        "
+      >
+        <div style="position: relative; text-align: center; width: 100%">
+          <hr />
+          <span
+            style="
+              position: absolute;
+              top: 50%;
+              left: 50%;
+              transform: translate(-50%, -50%);
+              background: white;
+              padding: 0 12px;
+            "
+          >
+            Other Ways to Sign In
+          </span>
+        </div>
+      </div>
+      <button
+        name="button"
+        value="otp"
+        gg-optional
+        gg-match="button#SignInWithOTPUsingEmailAddressExchange"
+      >
+        Receive a Passcode
+      </button>
+    </div>
   </body>
 </html>

--- a/tests/mcp/test_costco.py
+++ b/tests/mcp/test_costco.py
@@ -1,0 +1,49 @@
+"""Integration test for Costco auth flow."""
+
+import json
+import os
+from typing import Any
+
+import pytest
+import zendriver as zd
+from fastmcp import Client
+from mcp.types import TextContent
+
+
+@pytest.mark.mcp
+@pytest.mark.asyncio
+async def test_costco_auth_flow(mcp_config: dict[str, Any]):
+    """Verify Costco sign-in returns a signin URL and completes auth."""
+    client = Client(mcp_config, timeout=120)
+    async with client:
+        result = await client.call_tool("costco_get_orders")
+        assert isinstance(result.content[0], TextContent)
+        parsed = json.loads(result.content[0].text)
+        assert parsed.get("url"), "Expected signin URL"
+        assert parsed.get("signin_id"), "Expected signin_id"
+
+        signin_url = parsed["url"]
+        signin_id = parsed["signin_id"]
+
+        browser = await zd.start(no_sandbox=True, headless=True)
+        try:
+            page = await browser.get(signin_url)
+
+            email_input = await page.wait_for("input#signInName", timeout=30)
+            await email_input.send_keys(os.environ.get("COSTCO_EMAIL", ""))
+
+            password_input = await page.wait_for("input#password", timeout=10)
+            await password_input.send_keys(os.environ.get("COSTCO_PASSWORD", ""))
+
+            submit_btn = await page.wait_for("button#next:not([disabled])", timeout=10)
+            await submit_btn.click()
+
+            await page.wait_for(text="Finished!", timeout=60)
+        finally:
+            await browser.stop()
+
+        check = await client.call_tool("check_signin", {"signin_id": signin_id})
+        assert isinstance(check.content[0], TextContent)
+        check_result = json.loads(check.content[0].text)
+        assert check_result.get("status") == "SUCCESS"
+        assert check_result.get("completed") is True


### PR DESCRIPTION
## Summary

- **New:** `getgather/mcp/patterns/costco-pre-signin.html` — autoclick "Sign In / Register" button on costco.com
- **New:** `getgather/mcp/patterns/costco-signin.html` — fill email + password on Azure AD B2C signin form
- **New:** `getgather/mcp/patterns/costco-home-loggedin.html` — stop pattern when orders icon visible (confirms auth)
- **New:** `getgather/mcp/costco.py` — `get_orders` stub using `remote_zen_dpage_with_action`; returns empty list pending scraping
- **New:** `tests/mcp/test_costco.py` — MCP integration test for full auth flow
- `getgather/mcp/mcp-tools.yaml` — add costco entry (`custom: true`, `module: costco`)
- `getgather/mcp/main.py` — add `costco` to shopping bundle