### PR TITLE
Register test markers and clean up test configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ typecheck:
 
 .PHONY: test
 test:
-	uv run pytest -m "not api and not webui and not mcp and not distill"
+	uv run pytest --no-header --tb=no -q -m "not api and not mcp and not distill"
 
 .PHONY: check-patterns
 check-patterns:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,6 @@
 [pytest]
+filterwarnings =
+    ignore::DeprecationWarning:daytona
 testpaths = tests
 python_files = test_*.py
 python_functions = test_*
@@ -9,3 +11,4 @@ addopts = -v --cov=getgather --cov-report=term-missing
 markers =
     mcp: Tests for the MCP server.
     distill: Tests for the distillation functionality.
+    api: Tests for the browser API.

--- a/tests/test_browser_api_e2e.py
+++ b/tests/test_browser_api_e2e.py
@@ -31,8 +31,7 @@ class TestHealthEndpoint:
 
 @pytest.mark.api
 class TestBrowserLifecycle:
-    def __init__(self) -> None:
-        self.browser_ids: list[str] = []
+    browser_ids: list[str] = []
 
     @pytest.fixture(autouse=True)
     def cleanup(self, client: httpx.Client) -> Generator[None, None, None]:
@@ -87,8 +86,7 @@ class TestBrowserListing:
 
 @pytest.mark.api
 class TestAutoStart:
-    def __init__(self) -> None:
-        self.browser_ids: list[str] = []
+    browser_ids: list[str] = []
 
     @pytest.fixture(autouse=True)
     def cleanup(self, client: httpx.Client) -> Generator[None, None, None]:
@@ -121,8 +119,7 @@ class TestAutoStart:
 
 @pytest.mark.api
 class TestListPages:
-    def __init__(self) -> None:
-        self.browser_ids: list[str] = []
+    browser_ids: list[str] = []
 
     @pytest.fixture(autouse=True)
     def cleanup(self, client: httpx.Client) -> Generator[None, None, None]:
@@ -152,8 +149,7 @@ class TestListPages:
 
 @pytest.mark.api
 class TestPageContent:
-    def __init__(self) -> None:
-        self.browser_ids: list[str] = []
+    browser_ids: list[str] = []
 
     @pytest.fixture(autouse=True)
     def cleanup(self, client: httpx.Client) -> Generator[None, None, None]:


### PR DESCRIPTION
The browser API e2e tests use an `@pytest.mark.api` marker that was unregistered in pytest.ini, producing pytest warnings on every run. Register the marker, drop the obsolete `webui` exclusion from `make test` (the marker no longer exists), quiet the unit-test output with `--no-header --tb=no -q`, and suppress daytona DeprecationWarnings.

In `test_browser_api_e2e.py`, the four `__init__` methods that only set `self.browser_ids = []` are redundant with the autouse `cleanup` fixture, which already resets the list before each test. Replace them with shared class-level `browser_ids` attributes.

To verify, run `make test`.