### PR TITLE
fix: use last_activity_at from sandbox

### DIFF
--- a/getgather/browsers/daytona_browsers.py
+++ b/getgather/browsers/daytona_browsers.py
@@ -1,5 +1,6 @@
 import asyncio
 import time
+from datetime import datetime
 from typing import Any
 
 from daytona import (
@@ -69,6 +70,17 @@ LABEL_FLEET = "fleet"
 
 def _sandbox_name(browser_id: str) -> str:
     return f"{BROWSER_NAME_PREFIX}{browser_id}"
+
+
+def _parse_timestamp(value: str | None) -> float | None:
+    """A Daytona ISO-8601 timestamp as unix epoch, or None if absent/unparseable."""
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value).timestamp()
+    except ValueError:
+        logger.warning(f"Unparseable Daytona timestamp: {value!r}")
+        return None
 
 
 async def _configure_sandbox_proxy(sandbox: AsyncSandbox, proxy_url: str) -> bool:
@@ -340,9 +352,7 @@ class DaytonaBackend:
             "hostname": sandbox.name,
             "cdp_url": signed.url,  # public, internet-reachable; bearer secret (see SIGNED_URL_TTL_SECONDS)
             "app_state": sandbox.state,
-            # Reading Chrome's History DB uses process.exec, which Daytona counts as sandbox
-            # activity. Status polling must not extend the sandbox lifecycle.
-            "last_activity_timestamp": None,
+            "last_activity_timestamp": _parse_timestamp(sandbox.last_activity_at),
         }
 
     async def _get_last_activity(self, sandbox: AsyncSandbox) -> float | None:


### PR DESCRIPTION
## Why

Daytona sandboxes already provide `last_activity_at`, so use that instead of returning `None` or querying Chrome history from the sandbox.

## Tests

Three GETs over 45 s all returned the identical 1787827953.245. The value is frozen.

```bash
curl -sS http://remotebrowser-daytona.flycast/api/v1/browsers/Bvq2p8z97
{
  "hostname": "chromium-Bvq2p8z97",
  "cdp_url": "https://9222-<token>.daytonaproxy01.net",
  "app_state": "started",
  "last_activity_timestamp": 1787827953.245
}
```
