### PR TITLE
fix: close cdp connection after dpage request

### DIFF
--- a/getgather/browser.py
+++ b/getgather/browser.py
@@ -241,6 +241,22 @@ async def create_remote_browser(
     return browser
 
 
+async def close_remote_browser(browser: zd.Browser | None) -> None:
+    """Drop our CDP websockets for `browser`. The remote browser itself keeps running."""
+    if browser is None:
+        return
+
+    connections: list[Connection] = list(browser.targets)
+    if browser.connection is not None:
+        connections.append(browser.connection)
+
+    for connection in connections:
+        try:
+            await connection.aclose()
+        except Exception as e:
+            logger.debug(f"Ignored error closing CDP connection: {e}")
+
+
 async def terminate_remote_browser(browser: zd.Browser) -> None:
     """Terminate an existing remote Chrome via ChromeFleet."""
     browser_id = cast(str, browser.id)  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -18,6 +18,7 @@ from zendriver.core.connection import ProtocolException
 
 from getgather.browser import (
     ElementConfig,
+    close_remote_browser,
     create_remote_browser,
     find_browser_tab,
     get_new_page,
@@ -288,11 +289,14 @@ async def post_dpage(id: str, request: Request) -> HTMLResponse:
     if browser is None:
         raise HTTPException(status_code=404, detail="Remote browser not found")
 
-    page = find_browser_tab(browser, signin_id.target_id)
-    if page is None:
-        raise HTTPException(status_code=404, detail="Page not found")
+    try:
+        page = find_browser_tab(browser, signin_id.target_id)
+        if page is None:
+            raise HTTPException(status_code=404, detail="Page not found")
 
-    return await zen_post_dpage(page, id, request)
+        return await zen_post_dpage(page, id, request)
+    finally:
+        await close_remote_browser(browser)
 
 
 def is_local_address(host: str) -> bool:


### PR DESCRIPTION
## Why

The `@router.post("/{id}", response_class=HTMLResponse)` endpoint always creates a new CDP connection.

The endpoint calls `get_remote_browser()`, which always creates a new CDP WebSocket connection:

```python
async def get_remote_browser(browser_id: str) -> zd.Browser | None:
    logger.debug(f"Finding the ChromeFleet browser: {browser_id}")
    try:
        await call_chromefleet_api("GET", browser_id, timeout=30.0)
    except Exception:
        return None

    cdp_websocket_url = _setup_cdp_url(browser_id)
    logger.debug(f"Connecting to ChromeFleet CDP at {cdp_websocket_url}")
    browser = await _create_browser_from_cdp_websocket(
        browser_id=browser_id, websocket_url=cdp_websocket_url
    )
    return browser
```

From Logfire, I calculated the total CDP connection duration and found that these connections are never closed after the request completes.

The `dpage/{id}` endpoint is the largest contributor to these leaked connections.

<img width="1044" height="256" alt="image" src="https://github.com/user-attachments/assets/950b941b-f1b4-44f6-a427-5aa2a6451bc6" />

Other methods also appear to leak CDP connections. I will address each of those separately in follow-up PRs.

## Changes

Close the CDP connection after the `dpage` action completes.

## Test

Before the fix

```
[CDP-DEBUG] relay OPEN  Bleak5#1 open_now=1
[CDP-DEBUG] relay CLOSE Bleak5#1 lived=1.4s      <- /pages, CDPClient path, closes correctly
[CDP-DEBUG] relay OPEN  Bleak5#2 open_now=1      <- POST /dpage, browser socket
[CDP-DEBUG] relay OPEN  Bleak5#3 open_now=2      <- POST /dpage, page socket
[CDP-DEBUG] open relays: 2 -> Bleak5#2 age=11s
...
[CDP-DEBUG] open relays: 2 -> Bleak5#2 age=116s
[CDP-DEBUG] open relays: 2 -> Bleak5#2 age=131s  <- handler returned 23s earlier
```

POST /dpage returned 503 at 04:25:52. Both sockets were still open at 04:26:15 and still climbing when I stopped watching.

After the fix, identical flow

`
[CDP-DEBUG] relay OPEN  Bleak5#2 open_now=1
[CDP-DEBUG] relay OPEN  Bleak5#3 open_now=2
[CDP-DEBUG] open relays: 2 -> Bleak5#2 age=101s
[CDP-DEBUG] relay CLOSE Bleak5#3 lived=101.0s    <- handler returns
[CDP-DEBUG] relay CLOSE Bleak5#2 lived=108.1s
[CDP-DEBUG] open relays: 0
```