### PR TITLE
fix: close cdp sockets in the check_signin poll loop

### DIFF
--- a/getgather/browser.py
+++ b/getgather/browser.py
@@ -241,8 +241,12 @@ async def create_remote_browser(
     return browser
 
 
-async def close_remote_browser(browser: zd.Browser | None) -> None:
-    """Drop our CDP websockets for `browser`. The remote browser itself keeps running."""
+async def close_cdp_connections(browser: zd.Browser | None) -> None:
+    """Close our CDP websockets to `browser`: the browser socket and every page target.
+
+    Only the sockets. No CDP command is sent, so the remote browser keeps running with all
+    its tabs and a later `get_remote_browser` reconnects to the same session. 
+    """
     if browser is None:
         return
 

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -204,31 +204,36 @@ async def dpage_check(id: str):
     path = os.path.join(os.path.dirname(__file__), "patterns", "**/*.html")
     probe_patterns = load_distillation_patterns(path)
 
-    for iteration in range(max):
-        logger.debug(f"Checking dpage {id}: {iteration + 1} of {max}")
-        await asyncio.sleep(TICK)
+    try:
+        for iteration in range(max):
+            logger.debug(f"Checking dpage {id}: {iteration + 1} of {max}")
+            await asyncio.sleep(TICK)
 
-        if browser is None:
-            browser = await get_remote_browser(signin_id.browser_id)
-        if browser is None:
-            continue
+            if browser is None:
+                browser = await get_remote_browser(signin_id.browser_id)
+            if browser is None:
+                continue
 
-        page = find_browser_tab(browser, signin_id.target_id)
-        if page is None:
-            browser = None
-            continue
+            page = find_browser_tab(browser, signin_id.target_id)
+            if page is None:
+                await close_remote_browser(browser)
+                browser = None
+                continue
 
-        try:
-            terminated = await _probe_page(
-                page=page, browser=browser, timeout=2, patterns=probe_patterns
-            )
-            if terminated:
-                return True
-        except Exception as e:
-            logger.warning(f"Remote probe failed for {id}: {e}")
-            browser = None
+            try:
+                terminated = await _probe_page(
+                    page=page, browser=browser, timeout=2, patterns=probe_patterns
+                )
+                if terminated:
+                    return True
+            except Exception as e:
+                logger.warning(f"Remote probe failed for {id}: {e}")
+                await close_remote_browser(browser)
+                browser = None
 
-    return None
+        return None
+    finally:
+        await close_remote_browser(browser)
 
 
 async def dpage_finalize(id: str):

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -18,7 +18,7 @@ from zendriver.core.connection import ProtocolException
 
 from getgather.browser import (
     ElementConfig,
-    close_remote_browser,
+    close_cdp_connections,
     create_remote_browser,
     find_browser_tab,
     get_new_page,
@@ -216,7 +216,7 @@ async def dpage_check(id: str):
 
             page = find_browser_tab(browser, signin_id.target_id)
             if page is None:
-                await close_remote_browser(browser)
+                await close_cdp_connections(browser)
                 browser = None
                 continue
 
@@ -228,12 +228,12 @@ async def dpage_check(id: str):
                     return True
             except Exception as e:
                 logger.warning(f"Remote probe failed for {id}: {e}")
-                await close_remote_browser(browser)
+                await close_cdp_connections(browser)
                 browser = None
 
         return None
     finally:
-        await close_remote_browser(browser)
+        await close_cdp_connections(browser)
 
 
 async def dpage_finalize(id: str):
@@ -301,7 +301,7 @@ async def post_dpage(id: str, request: Request) -> HTMLResponse:
 
         return await zen_post_dpage(page, id, request)
     finally:
-        await close_remote_browser(browser)
+        await close_cdp_connections(browser)
 
 
 def is_local_address(host: str) -> bool:


### PR DESCRIPTION
## Why

dpage_check reconnects to the browser on every failed poll tick without closing the previous socket, leaking up to 120 CDP websockets per abandoned sign-in.

## Changes
- `dpage_check`: close the CDP sockets before each reconnect, and in a `finally` on every exit.
- Rename `close_remote_browser` → `close_cdp_connections`; it closes websockets only, never the browser.

## BEFORE fix

`scripts/cdp_leak_probe.py --flow check_signin --seconds 45`

```
CDP socket events
-----------------
  open   Bmm4wcawc#1      sockets=1  tracked_now=1
  open   Bmm4wcawc#2      sockets=1  tracked_now=2
  open   Bmm4wcawc#3      sockets=1  tracked_now=3
  open   Bmm4wcawc#4      sockets=1  tracked_now=4
  open   Bmm4wcawc#5      sockets=1  tracked_now=5
  open   Bmm4wcawc#6      sockets=1  tracked_now=6
  open   Bmm4wcawc#7      sockets=1  tracked_now=7
  open   Bmm4wcawc#8      sockets=1  tracked_now=8
  open   Bmm4wcawc#9      sockets=1  tracked_now=9
  open   Bmm4wcawc#10     sockets=1  tracked_now=10
  open   Bmm4wcawc#11     sockets=1  tracked_now=11
  open   Bmm4wcawc#12     sockets=1  tracked_now=12
  open   Bmm4wcawc#13     sockets=1  tracked_now=13
  open   Bmm4wcawc#14     sockets=1  tracked_now=14
  open   Bmm4wcawc#15     sockets=1  tracked_now=15
  (no close events — every socket opened was still open when the run ended)
```

flow held open   : 45.4s
browser          : Bmm4wcawc
sockets opened   : 15
sockets closed   : 0
still open at end: 15

LEAK: 15 of 15 CDP sockets were never closed.

## AFTER fix

```bash
scripts/cdp_leak_probe.py --flow check_signin --seconds 45
```

```
CDP socket events
-----------------
  open   Bzg5zmti3#1      sockets=1  tracked_now=1
  close  Bzg5zmti3#1      lived=0.02s  tracked_now=0
  open   Bzg5zmti3#2      sockets=1  tracked_now=1
  close  Bzg5zmti3#2      lived=0.34s  tracked_now=0
  open   Bzg5zmti3#3      sockets=1  tracked_now=1
  close  Bzg5zmti3#3      lived=0.15s  tracked_now=0
  open   Bzg5zmti3#4      sockets=1  tracked_now=1
  close  Bzg5zmti3#4      lived=0.43s  tracked_now=0
  open   Bzg5zmti3#5      sockets=1  tracked_now=1
  close  Bzg5zmti3#5      lived=0.19s  tracked_now=0
  open   Bzg5zmti3#6      sockets=1  tracked_now=1
  close  Bzg5zmti3#6      lived=0.21s  tracked_now=0
```

flow held open   : 45.9s
browser          : Bzg5zmti3
sockets opened   : 6
sockets closed   : 6
still open at end: 0
lifetime p50/max : 0.21s / 0.43s

CLEAN: all 6 CDP sockets were closed.
